### PR TITLE
Changing PrepareQuery to use FHIR server from configuration or from S…

### DIFF
--- a/api/src/main/java/com/lantanagroup/nandina/controller/ReportController.java
+++ b/api/src/main/java/com/lantanagroup/nandina/controller/ReportController.java
@@ -89,15 +89,19 @@ public class ReportController extends BaseController {
   @PostMapping("/api/query")
   public QueryReport getQuestionnaireResponse(Authentication authentication, HttpServletRequest request, @RequestBody() QueryReport report) throws Exception {
     IGenericClient fhirQueryClient = this.getFhirQueryClient(authentication, request);
+    IGenericClient fhirStoreClient = this.getFhirStoreClient(authentication, request);
     Map<String, String> criteria = this.getCriteria(request, report);
 
     logger.debug("Generating report, including criteria: " + criteria.toString());
 
     HashMap<String, Object> contextData = new HashMap<>();
+
     contextData.put("report", report);
+    contextData.put("fhirQueryClient", fhirQueryClient);
+    contextData.put("fhirStoreClient", fhirStoreClient);
 
     FhirHelper.recordAuditEvent(
-            fhirQueryClient,
+            fhirStoreClient,
             authentication,
             ReportController.class.getName(),
             "executeQuery()",

--- a/query/src/main/java/com/lantanagroup/nandina/query/fhir/r4/cerner/PrepareQuery.java
+++ b/query/src/main/java/com/lantanagroup/nandina/query/fhir/r4/cerner/PrepareQuery.java
@@ -17,8 +17,8 @@ public class PrepareQuery extends BasePrepareQuery {
     @Override
     public void execute() {
         FhirContext ctx = FhirContext.forR4();
-        IGenericClient ehrFhirServer = ctx.newRestfulGenericClient("https://nandina-fhir.lantanagroup.com/fhir");
-        IGenericClient nandinaFhirServer = ctx.newRestfulGenericClient("https://nandina-fhir.lantanagroup.com/fhir");
+        IGenericClient fhirQueryClient = (IGenericClient) this.getContextData("fhirQueryClient");
+        IGenericClient fhirStoreClient = (IGenericClient) this.getContextData("fhirStoreClient");
 
         List<String> idList = new ArrayList<>();
 
@@ -37,7 +37,7 @@ public class PrepareQuery extends BasePrepareQuery {
         idList.add("CER97953899g");
         idList.add("CER97953899h");
 
-        EncounterScoop encounterScoop = new EncounterScoop(ehrFhirServer, nandinaFhirServer, idList);
+        EncounterScoop encounterScoop = new EncounterScoop(fhirQueryClient, fhirStoreClient, idList);
 
         this.addContextData("scoopData", encounterScoop);
 

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --port 8080",
+    "start": "ng serve --port 8080 --disable-host-check",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
Changing PrepareQuery to use FHIR server from configuration or from Smart-on-FHIR launch context.
Disabling host check for debugging purposes in package.json's "start" script. This is needed to launch from the Cerner sandbox.