### PR TITLE
Connectathon

### DIFF
--- a/api/src/main/java/com/lantanagroup/nandina/controller/LocationController.java
+++ b/api/src/main/java/com/lantanagroup/nandina/controller/LocationController.java
@@ -52,8 +52,7 @@ public class LocationController extends BaseController {
             .returnBundle(Bundle.class)
             .execute();
 
-    FhirHelper.recordAuditEvent(fhirStoreClient, authentication, url, "LocationController/getLocations()",
-            "Location", "Search Locations", "Successful Location Search");
+    FhirHelper.recordAuditEvent(fhirStoreClient, authentication, FhirHelper.AuditEventTypes.SearchLocations, "Successful Location Search");
 
     logger.debug(String.format("Done searching locations. Found %s locations.", locationsBundle.getTotal()));
 

--- a/api/src/main/java/com/lantanagroup/nandina/controller/ReportController.java
+++ b/api/src/main/java/com/lantanagroup/nandina/controller/ReportController.java
@@ -126,6 +126,7 @@ public class ReportController extends BaseController {
     contextData.put("report", report);
     contextData.put("fhirQueryClient", fhirQueryClient);
     contextData.put("fhirStoreClient", fhirStoreClient);
+    contextData.put("queryCriteria", this.jsonProperties.getQueryCriteria());
 
     FhirHelper.recordAuditEvent(
             fhirStoreClient,

--- a/api/src/main/resources/config.json
+++ b/api/src/main/resources/config.json
@@ -13,6 +13,8 @@
     "scopes": "",
     "token": ""
   },
+  "queryCriteria": {
+  },
   "terminology": {
     "covidCodesValueSet": "classpath:2.16.840.1.113762.1.4.1146.1124.xml",
     "ventilatorCodesValueSet": "classpath:mechanical-ventilators.xml",

--- a/core/src/main/java/com/lantanagroup/nandina/JsonProperties.java
+++ b/core/src/main/java/com/lantanagroup/nandina/JsonProperties.java
@@ -41,6 +41,7 @@ public class JsonProperties {
     private Map<String, Map<String, String>> field;
     private boolean requireHttps;
     private Map<String, String> direct;
+    private Map<String, String> queryCriteria;
 
     public String getExportFormat() {
         return exportFormat;
@@ -170,5 +171,13 @@ public class JsonProperties {
 
     public void setFhirServerQueryAuth(Map<String, String> fhirServerQueryAuth) {
         this.fhirServerQueryAuth = fhirServerQueryAuth;
+    }
+
+    public Map<String, String> getQueryCriteria() {
+        return queryCriteria;
+    }
+
+    public void setQueryCriteria(Map<String, String> queryCriteria) {
+        this.queryCriteria = queryCriteria;
     }
 }

--- a/query/src/main/java/com/lantanagroup/nandina/query/fhir/r4/saner/Constants.java
+++ b/query/src/main/java/com/lantanagroup/nandina/query/fhir/r4/saner/Constants.java
@@ -2,6 +2,10 @@ package com.lantanagroup.nandina.query.fhir.r4.saner;
 
 public abstract class Constants {
   public static final String MEASURE_GROUP_SYSTEM = "http://hl7.org/fhir/us/saner/CodeSystem/MeasureGroupSystem";
-  public static final String MEASURE_POPULATION_SYSTEM = "http://hl7.org/fhir/us/saner/CodeSystem/MeasurePopulationSystem";
+  public static final String[] MEASURE_POPULATION_SYSTEMS = new String[] {
+          "http://hl7.org/fhir/us/saner/CodeSystem/MeasuredValues",
+          "http://hl7.org/fhir/us/saner/CodeSystem/MeasurePopulationSystem",
+          "http://hl7.org/fhir/us/saner/CodeSystem/MeasurePopulationSystem"
+  };
   public static final String MEASURE_URL = "http://hl7.org/fhir/us/saner/Measure/CDCPatientImpactAndHospitalCapacity";
 }

--- a/query/src/main/java/com/lantanagroup/nandina/query/fhir/r4/saner/FormQuery.java
+++ b/query/src/main/java/com/lantanagroup/nandina/query/fhir/r4/saner/FormQuery.java
@@ -5,14 +5,20 @@ import com.lantanagroup.nandina.query.BaseFormQuery;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.hl7.fhir.r4.model.Resource;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 public class FormQuery extends BaseFormQuery {
   private static boolean isPopulationMatch(MeasureReport.MeasureReportGroupPopulationComponent population, String populationCode) {
+    List<String> systems = Arrays.asList(Constants.MEASURE_POPULATION_SYSTEMS);
     if (population.getCode() != null && population.getCode().getCoding() != null && population.getCode().getCoding().size() > 0) {
       if (population.getCode().getCoding().get(0).getSystem() != null && population.getCode().getCoding().get(0).getCode() != null) {
-        return population.getCode().getCoding().get(0).getSystem().equals(Constants.MEASURE_POPULATION_SYSTEM) &&
-                population.getCode().getCoding().get(0).getCode().equals(populationCode);
+        if (!systems.contains(population.getCode().getCoding().get(0).getSystem())) {
+          return false;
+        }
+
+        return population.getCode().getCoding().get(0).getCode().equalsIgnoreCase(populationCode);
       }
     }
 
@@ -30,7 +36,7 @@ public class FormQuery extends BaseFormQuery {
     return false;
   }
 
-  private Integer countForPopulation(Map<String, Resource> data, String groupCode, String populationCode) {
+  private Integer countForPopulation(Map<String, Resource> data, String populationCode) {
     Integer total = null;
 
     if (data != null) {
@@ -38,8 +44,6 @@ public class FormQuery extends BaseFormQuery {
         MeasureReport mr = (MeasureReport) resource;
 
         for (MeasureReport.MeasureReportGroupComponent group : mr.getGroup()) {
-          if (!isGroupMatch(group, groupCode)) continue;
-
           for (MeasureReport.MeasureReportGroupPopulationComponent population : group.getPopulation()) {
             if (!isPopulationMatch(population, populationCode)) continue;
 
@@ -62,18 +66,18 @@ public class FormQuery extends BaseFormQuery {
 
     Map<String, Resource> data = (Map<String, Resource>) this.getContextData("measureReportData");
 
-    this.setAnswer(PIHCConstants.HOSPITALIZED, this.countForPopulation(data, "Encounters", "numC19HospPats"));
-    this.setAnswer(PIHCConstants.HOSPITALIZED_AND_VENTILATED, this.countForPopulation(data, "Encounters", "numC19MechVentPats"));
-    this.setAnswer(PIHCConstants.HOSPITAL_INPATIENT_BEDS, this.countForPopulation(data, "Beds", "numbeds"));
-    this.setAnswer(PIHCConstants.HOSPITAL_INPATIENT_BED_OCC, this.countForPopulation(data, "Beds", "numBedsOcc"));
-    this.setAnswer(PIHCConstants.HOSPITAL_ICU_BEDS, this.countForPopulation(data, "Beds", "numICUBeds"));
-    this.setAnswer(PIHCConstants.HOSPITAL_ICU_BED_OCC, this.countForPopulation(data, "Beds", "numICUBedsOcc"));
-    this.setAnswer(PIHCConstants.ED_OVERFLOW, this.countForPopulation(data, "Encounters", "numC19OverflowPats"));
-    this.setAnswer(PIHCConstants.ED_OVERFLOW_AND_VENT, this.countForPopulation(data, "Encounters", "numC19OFMechVentPats"));
-    this.setAnswer(PIHCConstants.PREVIOUS_DAY_DEATHS, this.countForPopulation(data, "Encounters", "numC19Died"));
-    this.setAnswer(PIHCConstants.MECHANICAL_VENTILATORS, this.countForPopulation(data, "Ventilators", "numVent"));
-    this.setAnswer(PIHCConstants.MECHANICAL_VENTILATORS_USED, this.countForPopulation(data, "Ventilators", "numVentUse"));
-    this.setAnswer(PIHCConstants.HOSPITAL_ONSET, this.countForPopulation(data, "Encounters", "numC19HOPats"));
-    this.setAnswer(PIHCConstants.ALL_HOSPITAL_BEDS, this.countForPopulation(data, "Beds", "numTotBeds"));
+    this.setAnswer("numC19HospPats", this.countForPopulation(data, "numC19HospPats"));
+    this.setAnswer("numC19MechVentPats", this.countForPopulation(data, "numC19MechVentPats"));
+    this.setAnswer("numC19HOPats", this.countForPopulation(data, "numC19HOPats"));
+    this.setAnswer("numC19OverflowPats", this.countForPopulation(data, "numC19OverflowPats"));
+    this.setAnswer("numC19OFMechVentPats", this.countForPopulation(data, "numC19OFMechVentPats"));
+    this.setAnswer("numC19Died", this.countForPopulation(data, "numC19Died"));
+    this.setAnswer("numTotBeds", this.countForPopulation(data, "numTotBeds"));
+    this.setAnswer("numBeds", this.countForPopulation(data, "numbeds"));
+    this.setAnswer("numBedsOcc", this.countForPopulation(data, "numBedsOcc"));
+    this.setAnswer("numICUBeds", this.countForPopulation(data, "numICUBeds"));
+    this.setAnswer("numICUBedsOcc", this.countForPopulation(data, "numICUBedsOcc"));
+    this.setAnswer("mechanicalVentilators", this.countForPopulation(data, "numVent"));
+    this.setAnswer("mechanicalVentilatorsUsed", this.countForPopulation(data, "numVentUse"));
   }
 }

--- a/query/src/main/java/com/lantanagroup/nandina/query/fhir/r4/saner/PrepareQuery.java
+++ b/query/src/main/java/com/lantanagroup/nandina/query/fhir/r4/saner/PrepareQuery.java
@@ -11,6 +11,7 @@ public class PrepareQuery extends BasePrepareQuery {
   public void execute() {
     String reportDate = this.criteria.get("reportDate");
     String overflowLocations = this.criteria.get("overflowLocations");
+    Map<String, String> queryCriteria = (Map<String, String>) this.contextData.get("queryCriteria");
 
     String url = String.format("MeasureReport?measure=%s&date=%s&",
             Helper.URLEncode(Constants.MEASURE_URL),
@@ -18,6 +19,12 @@ public class PrepareQuery extends BasePrepareQuery {
 
     if (overflowLocations != null && !overflowLocations.isEmpty()) {
       url += String.format("subject=%s&", overflowLocations);
+    }
+
+    if (queryCriteria != null) {
+      for (String key : queryCriteria.keySet()) {
+        url += String.format("%s=%s&", key, queryCriteria.get(key));
+      }
     }
 
     Map<String, Resource> results = this.search(url);

--- a/web/src/main/angular/app/questionnaire/questionnaire.component.html
+++ b/web/src/main/angular/app/questionnaire/questionnaire.component.html
@@ -57,8 +57,7 @@
             <td><strong>PREVIOUS DAY’S NEW HOSPITAL ONSET:</strong> Current inpatients hospitalized for a condition other than COVID-19 with onset of suspected or confirmed COVID-19 on the previous day and the previous day is fourteen or more days since admission</td>
         </tr>
         <tr>
-            <!-- TODO -->
-            <td><input type="number" class="form-control" /></td>
+            <td><input type="number" class="form-control" [(ngModel)]="report.answers['numConfC19HONewPats']" [class.is-invalid]="!report.answers['numConfC19HONewPats']" /></td>
             <td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Number of Previous Day’s New Hospital Onset with Confirmed COVID-19 (subset)</td>
         </tr>
         <tr>


### PR DESCRIPTION
Adding queryCriteria to configuration so that admins can indicate additional criteria to be added to FHIR server queries
Updating the SANER queries so that it uses multiple code systems to find data Nandina's interested in, as well as to update the fields' codes based on updates to the SANER IG

Setting field in UI to bind to correct answer

Changing AuditEvent creation to set the type isntead of subtype.
Making "type" based on pre-defined enum of options.
Fixing issue with export attempting to store AuditEvents in the query server, instead of the storage server.
Adding in TODO for filling in the "source" of an audit event.